### PR TITLE
no need to remove Invisible characters

### DIFF
--- a/src/Security.php
+++ b/src/Security.php
@@ -95,31 +95,6 @@ class Security
     {
         $output = $this->antiXss->xss_clean($input);
 
-        // remove invisible chars anyway
-        if ($this->antiXss->isXssFound() === false) {
-            return self::cleanInvisibleCharacters($output);
-        }
-
         return $output;
-    }
-
-    /**
-     * Clean invisible characters from the input.
-     *
-     * @param string|array $input
-     *
-     * @return string|array
-     */
-    private static function cleanInvisibleCharacters($input): string|array
-    {
-        if (is_array($input)) {
-            foreach ($input as $key => &$value) {
-                $value = self::cleanInvisibleCharacters($value);
-            }
-
-            return $input;
-        }
-
-        return UTF8::remove_invisible_characters($input, true);
     }
 }


### PR DESCRIPTION
no need to remove Invisible characters

Exp:
input : 
`<image src=x only=1 on\verror=(confirm)(1)>`
after clean xss will be get same input: 
`<image src=x only=1 on\verror=(confirm)(1)>`

and after that we will remove invisible characters and here the xss will run
`<image src=x only=1 onerror=(confirm)(1)>`

without remove Invisible characters
we will get
`<image src=x only=1 on\verror=(confirm)(1)>`
it's fine and the xss will not work
 
