### PR TITLE
:bug: fix double check after clean invisible chars and add more config

### DIFF
--- a/src/Security.php
+++ b/src/Security.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace GrahamCampbell\SecurityCore;
 
 use voku\helper\AntiXSS;
+use voku\helper\UTF8;
 
 /**
  * This is the security class.
@@ -101,6 +102,31 @@ class Security
     {
         $output = $this->antiXss->xss_clean($input);
 
+        // remove invisible chars anyway
+        if ($this->antiXss->isXssFound() === false) {
+            return self::cleanInvisibleCharacters($output);
+        }
+
         return $output;
+    }
+
+    /**
+     * Clean invisible characters from the input.
+     *
+     * @param string|array $input
+     *
+     * @return string|array
+     */
+    private static function cleanInvisibleCharacters($input): string|array
+    {
+        if (is_array($input)) {
+            foreach ($input as $key => &$value) {
+                $value = self::cleanInvisibleCharacters($value);
+            }
+
+            return $input;
+        }
+
+        return UTF8::remove_invisible_characters($input, true);
     }
 }

--- a/src/Security.php
+++ b/src/Security.php
@@ -104,7 +104,10 @@ class Security
 
         // remove invisible chars anyway
         if ($this->antiXss->isXssFound() === false) {
-            return self::cleanInvisibleCharacters($output);
+            $newOutput = self::cleanInvisibleCharacters($output);
+
+            // sometimes we get xss issues after clean invisible characters so we should check the new output
+            return $newOutput == $output ? $output : $this->antiXss->xss_clean($newOutput);
         }
 
         return $output;

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -218,7 +218,7 @@ class SecurityTest extends TestCase
 
             ],
             [
-                '<foo prefixOnAttribute="bar">%0b'."\0",
+                '<foo prefixOnAttribute="bar">',
                 '<foo prefixOnAttribute="bar">',
             ],
             [
@@ -241,6 +241,11 @@ class SecurityTest extends TestCase
                 '<svg/onload=alert(1)',
                 '&lt;svg/',
             ],
+            [
+                '<image src=x on\verror=(confirm)(1)>',
+                '<image src=x on\verror=(confirm)(1)>',
+            ],
+            
         ];
 
         return $cases;

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -218,7 +218,7 @@ class SecurityTest extends TestCase
 
             ],
             [
-                '<foo prefixOnAttribute="bar">',
+                '<foo prefixOnAttribute="bar">%0b'."\0",
                 '<foo prefixOnAttribute="bar">',
             ],
             [
@@ -241,11 +241,6 @@ class SecurityTest extends TestCase
                 '<svg/onload=alert(1)',
                 '&lt;svg/',
             ],
-            [
-                '<image src=x on\verror=(confirm)(1)>',
-                '<image src=x on\verror=(confirm)(1)>',
-            ],
-            
         ];
 
         return $cases;


### PR DESCRIPTION
1-  double check after clean invisible chars

Exp:
input :
`<image src=x only=1 on\verror=(confirm)(1)>`
after clean xss will be get same input:
`<image src=x only=1 on\verror=(confirm)(1)>`

and after that we will clean invisible characters and here the xss will run
`<image src=x only=1 onerror=(confirm)(1)>`

so we should double check after clean invisible chars

---
2- add config to add more 'never allowed On Events' and others

